### PR TITLE
add --read-link option for better one-liners

### DIFF
--- a/src/cfurl.rs
+++ b/src/cfurl.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-use std::{error::Error, path::Path, ptr};
+use std::{path::Path, ptr};
 
 use anyhow::anyhow;
 use anyhow::Result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,14 @@ mod cfurl;
 #[derive(Parser)]
 #[clap(about, author, version)]
 struct Options {
+    #[clap(
+        short = 'L',
+        long,
+        help = "Treat the source as a symbolic link",
+        long_help = "Treat the source as a symbolic link. Instead of creating an alias \
+            to the source, create an alias to the target of the source."
+    )]
+    read_link: bool,
     /// The target of the alias
     source: PathBuf,
     /// The name of the alias to create
@@ -17,8 +25,17 @@ struct Options {
 
 fn main() {
     let options = Options::parse();
-    let result = cfurl::create_alias(options.source, options.destination);
-    if let Err(error) = result {
+
+    if let Err(error) = run(options) {
         eprintln!("ERROR: {}", error);
     }
+}
+
+fn run(mut options: Options) -> anyhow::Result<()> {
+    if options.read_link {
+        options.source = std::fs::read_link(&options.source)?;
+    }
+
+    cfurl::create_alias(options.source, options.destination)?;
+    Ok(())
 }


### PR DESCRIPTION
While incorporating `mkAlias` into my activation scripts for my dotfiles, I found that using a bash for-loop meant that paths such as `/nix/store/some-hash/Applications/Visual Studio Code.app` would result in attempting to call `mkAlias` on each of `/nix/store/some-hash/Applications/Visual`, `Studio`, and `Code.app`.

As a Rustacean, I've been using [`fd`](https://github.com/sharkdp/fd) instead of UNIX `find` for all my finding, and with its convenient `-x` option the activation script may be written as:
```sh
app_path="$HOME/Applications/Home Manager Apps"
echo "Linking Home Manager applications from ${apps} to $app_path..." 2>&1

tmp_path="$(mktemp -dt "home-manager-applications.XXXXXXXXXX")" || exit 1

${pkgs.fd}/bin/fd \
  -t l -d 1 . ${apps}/Applications \
  -x $DRY_RUN_CMD ${mkAlias.outputs.apps.${system}.default.program} -L {} "$tmp_path/{/}"

$DRY_RUN_CMD rm -rf "$app_path"
$DRY_RUN_CMD mv "$tmp_path" "$app_path"
```

This pr adds the `--read-link` option to the CLI, which overwrites `options.source` with the successful result of `std::fs::read_link`, or returns an error. The short flag `-L` is inspired by the `--follow-symlink` arg of ls, lsd, exa, etc.

I also did some minor refactoring to keep error handling DRY (basically just use `anyhow::Result` instead of `Result<T, Box<dyn std::error::Error>>`), hope you don't mind :)