### PR TITLE
Update cargoHash in default.nix to build mkalias 0.3.0 with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage {
 
   src = ./.;
 
-  cargoHash = "sha256-7oIs9/ghs9oMwcVph11yko+eZmQINwSA64lEvfYivpk=";
+  cargoHash = "sha256-OG+VNDmsk68VvufWBBA4xayZm7f6QIf30JX9nBXTB3c=";
 
   meta = {
     description = info.package.description;


### PR DESCRIPTION
To fix this error:

```
$ nix build
error: hash mismatch in fixed-output derivation '/nix/store/pvvqvzidb6pzkh83d6nr7kgyz8cfdrcx-mkalias-0.3.0-vendor.tar.gz.drv':
         specified: sha256-7oIs9/ghs9oMwcVph11yko+eZmQINwSA64lEvfYivpk=
            got:    sha256-OG+VNDmsk68VvufWBBA4xayZm7f6QIf30JX9nBXTB3c=
error: 1 dependencies of derivation '/nix/store/z97vnhjlg7kjv590h5zmff3fg8iqqa74-mkalias-0.3.0.drv' failed to build
```